### PR TITLE
Advertise Chrome headers size limit

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -27,6 +27,10 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
 			name:	'X-FirePHP-Version',
 			value:	'0.0.6'
 		});
+		details.requestHeaders.push({
+			name:	'X-FirePHP-MaxCombinedHeaderSize',
+			value:	'256'
+		});
 		return {
 			requestHeaders: details.requestHeaders
 		};


### PR DESCRIPTION
Advertise Chrome headers size limit so FirePHP can truncate headers accordingly.

This is to solve https://github.com/firephp/firephp-core/issues/10 and require that the pull request https://github.com/firephp/firephp-core/pull/11 is merged.
