### PR TITLE
fix #28

### DIFF
--- a/src/js/devtools.js
+++ b/src/js/devtools.js
@@ -208,7 +208,10 @@ function FirePHP4Chrome() {
 		            }
 	            }
 
-                params.push(message);
+                if (message !== null) {
+                    // message "should" be null for groups, but if it's not, add it as a param
+                    params.push(message);
+                }
                 commandObject = {
                     type: consoleGroupCommand,
                     params: params


### PR DESCRIPTION
for group_start:
only add "message" param to params list if non-null  (it should be null)